### PR TITLE
fix: fix location of target folder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ config.targetEPSG.each { epsg ->
 
     // target
     String targetName = "$name-$epsg"
-    File targetFolder = settings.targetFolder ? project.file(settings.targetFolder) : new File('result', targetName)
+    File targetFolder = settings.targetFolder ? new File(configBasePath, settings.targetFolder) : new File('result', targetName)
 
     task("transform-$name-$epsg", type: hale.transform()) {
       assert projectFile != null


### PR DESCRIPTION
This fixes that the target folder was not created inside the folder specified by the `configBasePath` setting.

WGS-1453