### PR TITLE
Fix problem with incomplete CLI transformation result

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,12 +49,22 @@ config.targetEPSG.each { epsg ->
       assert projectFile != null
       transformation = projectFile
 
-      settings.sourceFolders.each { sourceFolder ->
-        source(new File(configBasePath, sourceFolder)) {
+      settings.shapefiles.each { shapefile ->
+        source(new File(configBasePath, shapefile.path)) {
           provider 'eu.esdihumboldt.hale.io.shape.reader.instance'
-          include '*.shp'
+          include "${shapefile.filename}"
           setting 'contentType', 'eu.esdihumboldt.hale.io.shp'
-          //setting 'defaultSrs', 'code:EPSG:2056'
+          setting 'typename', "${shapefile.typename}"
+        }
+      }
+
+      settings.table.sheets.each { sheet ->
+        source(new File(configBasePath, settings.table.path)) {
+          provider 'eu.esdihumboldt.hale.io.xls.reader.instance'
+          setting 'contentType', 'eu.esdihumboldt.hale.io.xls.xlsx'
+          setting 'typename', "${sheet.typename}"
+          setting 'sheetIndex', "${sheet.index}"
+          setting 'skip', '2'
         }
       }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
   }
   dependencies {
     classpath 'to.wetransform.hale:gradle-hale-plugin:1.2.0-SNAPSHOT'
+    classpath 'commons-io:commons-io:2.11.0'
   }
 }
 
@@ -18,6 +19,8 @@ apply plugin: 'to.wetransform.hale'
 hale {
   cliVersion = '4.2.0-SNAPSHOT'
 }
+
+import org.apache.commons.io.FileUtils
 
 /*
  * Configuration file
@@ -96,6 +99,7 @@ config.targetEPSG.each { epsg ->
 
     tasks["transform-$name-$epsg"].doFirst {
       targetFolder.mkdirs()
+      FileUtils.cleanDirectory(targetFolder)
     }
     
     tasks['transform-all'].dependsOn("transform-$name-$epsg")

--- a/config.json
+++ b/config.json
@@ -4,36 +4,167 @@
   "transformations": {
     "majorroad": {
       "project": "majorroad/DF4_8_majorroads_xls+shp-to-geopackage.halez",
-      "sourceFolders": [
-        "majorroad/input"
+      "shapefiles": [
+        {
+          "path": "majorroad/input",
+          "filename": "lden.shp",
+          "typename": "NoiseContours_Lden"
+        },
+        {
+          "path": "majorroad/input",
+          "filename": "lnight.shp",
+          "typename": "NoiseContours_Lnight"
+        }
       ],
+      "table": {
+        "path": "majorroad/input/table.xlsx",
+        "sheets": [
+          {
+            "index": "0",
+            "typename": "DF4_8_StraßenverkehrAllgemein"
+          },
+          {
+            "index": "1",
+            "typename": "DF4_8_StraßenverkehrMenschen"
+          },
+          {
+            "index": "2",
+            "typename": "DF4_8_StraßenverkehrSonstige"
+          }
+        ]
+      },
       "targetFolder": "majorroad/output",
       "targetFileName": "majorroad.gpkg"
     },
     "majorair": {
       "project": "majorair/DF4_8_majorairports_xls-to-geopackage-template.halez",
-      "sourceFolders": [
-        "majorair/input"
+      "shapefiles": [
+        {
+          "path": "majorair/input",
+          "filename": "lden.shp",
+          "typename": "NoiseContours_Lden"
+        },
+        {
+          "path": "majorair/input",
+          "filename": "lnight.shp",
+          "typename": "NoiseContours_Lnight"
+        }
       ],
+      "table": {
+        "path": "majorair/input/table.xlsx",
+        "sheets": [
+          {
+            "index": "0",
+            "typename": "DF4_8_GroßflughafenAllgemein"
+          },
+          {
+            "index": "1",
+            "typename": "DF4_8_GroßflughafenMenschen"
+          },
+          {
+            "index": "2",
+            "typename": "DF4_8_GroßflughafenSonstige"
+          }
+        ]
+      },
       "targetFolder": "majorair/output",
       "targetFileName": "majorair.gpkg"
     },
     "majorrail": {
       "project": "majorrail/DF4_8_majorrailways_xls+shp-to-geopackage.halez",
-      "sourceFolders": [
-        "majorrail/input"
+      "shapefiles": [
+        {
+          "path": "majorrail/input",
+          "filename": "lden.shp",
+          "typename": "NoiseContours_Lden"
+        },
+        {
+          "path": "majorrail/input",
+          "filename": "lnight.shp",
+          "typename": "NoiseContours_Lnight"
+        }
       ],
+      "table": {
+        "path": "majorrail/input/table.xlsx",
+        "sheets": [
+          {
+            "index": "0",
+            "typename": "DF4_8_SchienenverkehrAllgemein"
+          },
+          {
+            "index": "1",
+            "typename": "DF4_8_SchienenverkehrMenschen"
+          },
+          {
+            "index": "2",
+            "typename": "DF4_8_SchienenverkehrSonstige"
+          }
+        ]
+      },
       "targetFolder": "majorrail/output",
       "targetFileName": "majorrail.gpkg"
     },
     "agg": {
       "project": "agg/DF4_8_agglomerations_xls+shp-to-geopackage.halez",
-      "sourceFolders": [
-        "agg/input/aggroad",
-        "agg/input/aggrail",
-        "agg/input/aggair",
-        "agg/input/aggind"
+      "shapefiles": [
+        {
+          "path": "agg/input/aggroad",
+          "filename": "lden.shp",
+          "typename": "NoiseContours_roadsInAgglomeration_Lden"
+        },
+        {
+          "path": "agg/input/aggroad",
+          "filename": "lnight.shp",
+          "typename": "NoiseContours_roadsInAgglomeration_Lnight"
+        },
+        {
+          "path": "agg/input/aggrail",
+          "filename": "lden.shp",
+          "typename": "NoiseContours_railwaysInAgglomeration_Lden"
+        },
+        {
+          "path": "agg/input/aggrail",
+          "filename": "lnight.shp",
+          "typename": "NoiseContours_railwaysInAgglomeration_Lnight"
+        },
+        {
+          "path": "agg/input/aggair",
+          "filename": "lden.shp",
+          "typename": "NoiseContours_airportsInAgglomeration_Lden"
+        },
+        {
+          "path": "agg/input/aggair",
+          "filename": "lnight.shp",
+          "typename": "NoiseContours_airportsInAgglomeration_Lnight"
+        },
+        {
+          "path": "agg/input/aggind",
+          "filename": "lden.shp",
+          "typename": "NoiseContours_industryInAgglomeration_Lden"
+        },
+        {
+          "path": "agg/input/aggind",
+          "filename": "lnight.shp",
+          "typename": "NoiseContours_industryInAgglomeration_Lnight"
+        }
       ],
+      "table": {
+        "path": "agg/input/table.xlsx",
+        "sheets": [
+          {
+            "index": "0",
+            "typename": "DF4_8_AgglomerationAllgemein"
+          },
+          {
+            "index": "1",
+            "typename": "DF4_8_AgglomerationLärmquellen"
+          },
+          {
+            "index": "2",
+            "typename": "DF4_8_AgglomerationMenschen"
+          }
+        ]
+      },
       "targetFolder": "agg/output",
       "targetFileName": "agg.gpkg"
     }


### PR DESCRIPTION
Previously, the CLI transformation wasn't configured in a way that made sure
that the loaded source files are loaded into the correct types of the source
schema. This led to the situation that the generated GeoPackage output files
were incomplete.

This extends the configuration so that the target type for each Shapefile can
be provided. Also, the import of the Excel tables can be configured in more
detail to allow reading multiple sheets.

Also cleans the output folder(s) of the transformations before they are executed.

SVC-1216